### PR TITLE
Pregame Room Team Selection

### DIFF
--- a/Codenames.xcodeproj/project.pbxproj
+++ b/Codenames.xcodeproj/project.pbxproj
@@ -10,6 +10,7 @@
 		63067C6A1D2982DD0005AC66 /* LobbyRoomViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63067C691D2982DD0005AC66 /* LobbyRoomViewCell.swift */; };
 		63067C6C1D2996B60005AC66 /* Lobby.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63067C6B1D2996B60005AC66 /* Lobby.swift */; };
 		63920A371D3090D60073E7F7 /* MultipeerManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63920A361D3090D60073E7F7 /* MultipeerManager.swift */; };
+		639BA3161D38AFEF002F2A18 /* UIColor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 639BA3151D38AFEF002F2A18 /* UIColor.swift */; };
 		63A04D041D1A5713005A2914 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63A04D031D1A5713005A2914 /* AppDelegate.swift */; };
 		63A04D091D1A5713005A2914 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 63A04D071D1A5713005A2914 /* Main.storyboard */; };
 		63A04D0C1D1A5713005A2914 /* Codenames.xcdatamodeld in Sources */ = {isa = PBXBuildFile; fileRef = 63A04D0A1D1A5713005A2914 /* Codenames.xcdatamodeld */; };
@@ -32,6 +33,7 @@
 		63067C691D2982DD0005AC66 /* LobbyRoomViewCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = LobbyRoomViewCell.swift; path = Views/LobbyRoomViewCell.swift; sourceTree = "<group>"; };
 		63067C6B1D2996B60005AC66 /* Lobby.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = Lobby.swift; path = Objects/Lobby.swift; sourceTree = "<group>"; };
 		63920A361D3090D60073E7F7 /* MultipeerManager.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = MultipeerManager.swift; path = Managers/MultipeerManager.swift; sourceTree = "<group>"; };
+		639BA3151D38AFEF002F2A18 /* UIColor.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = UIColor.swift; path = Extensions/UIColor.swift; sourceTree = "<group>"; };
 		63A04D001D1A5713005A2914 /* Codenames.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Codenames.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		63A04D031D1A5713005A2914 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		63A04D081D1A5713005A2914 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/Main.storyboard; sourceTree = "<group>"; };
@@ -121,6 +123,7 @@
 			children = (
 				63A04D1C1D1A7F37005A2914 /* CodenamesButton.swift */,
 				63FA54DF1D1BBB73004515DA /* CodenamesTextField.swift */,
+				639BA3151D38AFEF002F2A18 /* UIColor.swift */,
 			);
 			name = Extensions;
 			sourceTree = "<group>";
@@ -232,6 +235,7 @@
 				63A04D1F1D1A7F3E005A2914 /* MainMenuViewController.swift in Sources */,
 				63920A371D3090D60073E7F7 /* MultipeerManager.swift in Sources */,
 				63FDED411D265F6D00142780 /* LobbyRoomViewController.swift in Sources */,
+				639BA3161D38AFEF002F2A18 /* UIColor.swift in Sources */,
 				63A04D0C1D1A5713005A2914 /* Codenames.xcdatamodeld in Sources */,
 				63FDED391D26557200142780 /* Room.swift in Sources */,
 				63FA54E01D1BBB73004515DA /* CodenamesTextField.swift in Sources */,

--- a/Codenames/Base.lproj/Main.storyboard
+++ b/Codenames/Base.lproj/Main.storyboard
@@ -352,10 +352,18 @@
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="d84-Az-a9v">
-                                                    <rect key="frame" x="40" y="3" width="68.5" height="37"/>
+                                                    <rect key="frame" x="40" y="3" width="431" height="37"/>
+                                                    <constraints>
+                                                        <constraint firstAttribute="width" constant="300" id="xaW-k5-dCT"/>
+                                                    </constraints>
                                                     <fontDescription key="fontDescription" name="HelveticaNeue-UltraLight" family="Helvetica Neue" pointSize="32"/>
                                                     <color key="textColor" cocoaTouchSystemColor="darkTextColor"/>
                                                     <nil key="highlightedColor"/>
+                                                    <variation key="default">
+                                                        <mask key="constraints">
+                                                            <exclude reference="xaW-k5-dCT"/>
+                                                        </mask>
+                                                    </variation>
                                                 </label>
                                                 <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="ajc-po-6pQ">
                                                     <rect key="frame" x="530" y="7" width="30" height="30"/>
@@ -369,7 +377,7 @@
                                                     </connections>
                                                 </button>
                                                 <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="VDC-S1-aKD" userLabel="Edit Button">
-                                                    <rect key="frame" x="535" y="9.5" width="25" height="25"/>
+                                                    <rect key="frame" x="535" y="10" width="25" height="25"/>
                                                     <constraints>
                                                         <constraint firstAttribute="width" constant="25" id="ESH-n1-TvZ"/>
                                                         <constraint firstAttribute="height" constant="25" id="Yew-IE-JHV"/>
@@ -379,19 +387,30 @@
                                                         <action selector="onEdit:" destination="PVh-e3-TPn" eventType="touchUpInside" id="Fjc-hL-Tr0"/>
                                                     </connections>
                                                 </button>
+                                                <switch opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" on="YES" translatesAutoresizingMaskIntoConstraints="NO" id="4xn-Al-HcR" userLabel="Team Switch">
+                                                    <rect key="frame" x="476" y="7" width="51" height="31"/>
+                                                    <connections>
+                                                        <action selector="switchToggled:" destination="PVh-e3-TPn" eventType="valueChanged" id="5x8-pM-NNx"/>
+                                                    </connections>
+                                                </switch>
                                             </subviews>
                                             <constraints>
+                                                <constraint firstItem="4xn-Al-HcR" firstAttribute="centerY" secondItem="rq2-uF-F29" secondAttribute="centerY" id="0zb-fE-yi0"/>
                                                 <constraint firstItem="d84-Az-a9v" firstAttribute="centerY" secondItem="rq2-uF-F29" secondAttribute="centerY" id="1oP-67-mY5"/>
                                                 <constraint firstItem="ajc-po-6pQ" firstAttribute="centerY" secondItem="rq2-uF-F29" secondAttribute="centerY" id="9Qp-wh-c4h"/>
                                                 <constraint firstItem="ajc-po-6pQ" firstAttribute="leading" secondItem="VDC-S1-aKD" secondAttribute="trailing" id="DbS-Kn-HR7"/>
+                                                <constraint firstItem="4xn-Al-HcR" firstAttribute="leading" secondItem="d84-Az-a9v" secondAttribute="trailing" constant="5" id="FFO-1C-XBM"/>
+                                                <constraint firstItem="4xn-Al-HcR" firstAttribute="leading" secondItem="d84-Az-a9v" secondAttribute="trailing" id="FZz-pq-zND"/>
                                                 <constraint firstItem="VDC-S1-aKD" firstAttribute="centerY" secondItem="rq2-uF-F29" secondAttribute="centerY" id="GdE-tE-tff"/>
                                                 <constraint firstAttribute="trailing" secondItem="ajc-po-6pQ" secondAttribute="trailing" constant="40" id="LTp-nn-DnX"/>
                                                 <constraint firstAttribute="trailing" secondItem="ajc-po-6pQ" secondAttribute="trailing" constant="40" id="dBw-J4-M4o"/>
+                                                <constraint firstItem="ajc-po-6pQ" firstAttribute="leading" secondItem="4xn-Al-HcR" secondAttribute="trailing" constant="5" id="f81-gi-erl"/>
                                                 <constraint firstAttribute="trailing" secondItem="VDC-S1-aKD" secondAttribute="trailing" constant="40" id="smY-Rb-iLV"/>
                                                 <constraint firstItem="d84-Az-a9v" firstAttribute="leading" secondItem="rq2-uF-F29" secondAttribute="leading" constant="40" id="unX-kK-LLJ"/>
                                             </constraints>
                                             <variation key="default">
                                                 <mask key="constraints">
+                                                    <exclude reference="FZz-pq-zND"/>
                                                     <exclude reference="DbS-Kn-HR7"/>
                                                     <exclude reference="dBw-J4-M4o"/>
                                                 </mask>
@@ -401,6 +420,7 @@
                                             <outlet property="editButton" destination="VDC-S1-aKD" id="sAt-Nd-9s8"/>
                                             <outlet property="nameLabel" destination="d84-Az-a9v" id="6T9-Jb-ZH6"/>
                                             <outlet property="removeButton" destination="ajc-po-6pQ" id="B86-EV-OzP"/>
+                                            <outlet property="teamSwitch" destination="4xn-Al-HcR" id="WxV-HX-LhQ"/>
                                         </connections>
                                     </tableViewCell>
                                 </prototypes>
@@ -488,7 +508,7 @@
         <image name="Spy" width="290" height="280"/>
     </resources>
     <inferredMetricsTieBreakers>
-        <segue reference="Vg7-zN-QuD"/>
+        <segue reference="M2x-yW-um3"/>
         <segue reference="87V-6a-5kI"/>
         <segue reference="yme-7x-s1N"/>
     </inferredMetricsTieBreakers>

--- a/Codenames/Extensions/UIColor.swift
+++ b/Codenames/Extensions/UIColor.swift
@@ -1,0 +1,11 @@
+import UIKit
+
+extension UIColor {
+    static func codenamesRedColor() -> UIColor {
+        return UIColor.init(colorLiteralRed: 239/255, green: 83/255, blue: 80/255, alpha: 1.0)
+    }
+    
+    static func codenamesBlueColor() -> UIColor {
+        return UIColor.init(colorLiteralRed: 66/255, green: 165/255, blue: 245/255, alpha: 1.0)
+    }
+}

--- a/Codenames/Objects/Player.swift
+++ b/Codenames/Objects/Player.swift
@@ -61,6 +61,10 @@ class Player: NSObject, NSCoding {
         self.team = team
     }
     
+    func getTeam() -> Team {
+        return self.team
+    }
+    
     func setClueGiver() {
         self.clueGiver = true
     }

--- a/Codenames/ViewControllers/CreateGameViewController.swift
+++ b/Codenames/ViewControllers/CreateGameViewController.swift
@@ -20,7 +20,7 @@ class CreateGameViewController: UIViewController, UITextFieldDelegate {
         guard let text = roomNameTextField.text else { return true }
         
         let length = text.characters.count + string.characters.count - range.length
-        return length <= 12
+        return length <= 8
     }
     
     func textFieldShouldReturn(textField: UITextField) -> Bool {

--- a/Codenames/ViewControllers/JoinGameViewController.swift
+++ b/Codenames/ViewControllers/JoinGameViewController.swift
@@ -20,7 +20,7 @@ class JoinGameViewController: UIViewController, UITextFieldDelegate {
         guard let text = userNameTextField.text else { return true }
         
         let length = text.characters.count + string.characters.count - range.length
-        return length <= 12
+        return length <= 8
     }
     
     func textFieldShouldReturn(textField: UITextField) -> Bool {

--- a/Codenames/ViewControllers/PregameRoomViewController.swift
+++ b/Codenames/ViewControllers/PregameRoomViewController.swift
@@ -114,6 +114,13 @@ class PregameRoomViewController: UIViewController, UITableViewDelegate, UITableV
         let playerAtIndex = room.getPlayers()[indexPath.row]
         cell.nameLabel.text = String(indexPath.row + 1) + ". " + playerAtIndex.getPlayerName()
         
+        // Determine team switch color
+        if playerAtIndex.getTeam() == Team.Red {
+            cell.teamSwitch.on = true
+        } else {
+            cell.teamSwitch.on = false
+        }
+        
         // Only host player can remove players
         if player.isHost() {
             cell.removeButton.hidden = false
@@ -124,11 +131,15 @@ class PregameRoomViewController: UIViewController, UITableViewDelegate, UITableV
         if player == playerAtIndex {
             cell.removeButton.hidden = true
             cell.editButton.hidden = false
+            cell.teamSwitch.enabled = true
         } else {
             cell.editButton.hidden = true
+            cell.teamSwitch.enabled = false
         }
         
         cell.index = indexPath.row
+        
+        
         
         cell.delegate = self
         
@@ -214,6 +225,15 @@ class PregameRoomViewController: UIViewController, UITableViewDelegate, UITableV
         alertController.addAction(cancelAction)
         alertController.addAction(confirmAction)
         self.presentViewController(alertController, animated: true, completion: nil)
+    }
+    
+    func teamDidChange(redTeam: Bool) {
+        if redTeam {
+            self.room.getPlayerWithUUID(self.player.getPlayerUUID())?.setTeam(Team.Red)
+        } else {
+            self.room.getPlayerWithUUID(self.player.getPlayerUUID())?.setTeam(Team.Blue)
+        }
+        self.broadcastData()
     }
 }
 

--- a/Codenames/Views/PregameRoomViewCell.swift
+++ b/Codenames/Views/PregameRoomViewCell.swift
@@ -3,15 +3,27 @@ import UIKit
 protocol PregameRoomViewCellDelegate {
     func editPlayerAtIndex(index: Int)
     func removePlayerAtIndex(index: Int)
+    func teamDidChange(team: Bool)
 }
 
 class PregameRoomViewCell: UITableViewCell {
+    let onColor = UIColor.codenamesRedColor()
+    let offColor = UIColor.codenamesBlueColor()
+    
     var index: Int?
     var delegate: PregameRoomViewCellDelegate?
     
     @IBOutlet weak var editButton: UIButton!
     @IBOutlet weak var nameLabel: UILabel!
     @IBOutlet weak var removeButton: UIButton!
+    @IBOutlet weak var teamSwitch: UISwitch!
+    
+    override func awakeFromNib() {
+        self.teamSwitch.onTintColor = self.onColor
+        self.teamSwitch.tintColor = self.offColor
+        self.teamSwitch.layer.cornerRadius = 16
+        self.teamSwitch.backgroundColor = self.offColor
+    }
     
     @IBAction func onRemove(sender: AnyObject) {
         if let index = index {
@@ -25,5 +37,7 @@ class PregameRoomViewCell: UITableViewCell {
         }
     }
     
-    override func awakeFromNib() {}
+    @IBAction func switchToggled(sender: AnyObject) {
+        delegate?.teamDidChange(teamSwitch.on)
+    }
 }


### PR DESCRIPTION
Features:

- Support local player toggling of team between Team Red/Blue, synchronizes with all participating devices
- Does not allow toggling of other players' team selections
- Starts off with default red
- Due to Autolayout issues, length of player name is restricted to 8 for now.