### PR TITLE
Increase broadcast interval to 2 seconds to reduce thrashing

### DIFF
--- a/Codenames/ViewControllers/PregameRoomViewController.swift
+++ b/Codenames/ViewControllers/PregameRoomViewController.swift
@@ -54,7 +54,7 @@ class PregameRoomViewController: UIViewController, UITableViewDelegate, UITableV
                 self.connectedPeers[peerID] = self.player.getPlayerUUID()
             }
             
-            self.broadcastTimer = NSTimer.scheduledTimerWithTimeInterval(1.0, target: self, selector: #selector(PregameRoomViewController.broadcastData), userInfo: nil, repeats: true)      // Broadcast host's room every second
+            self.broadcastTimer = NSTimer.scheduledTimerWithTimeInterval(2.0, target: self, selector: #selector(PregameRoomViewController.broadcastData), userInfo: nil, repeats: true)      // Broadcast host's room every 2 seconds
         }
         else {
             self.startGame.hidden = true


### PR DESCRIPTION
Features:

- In order to help reduce thrashing when all players are modifying themselves and sending out broadcast simultaneously, increase broadcast interval to 2 seconds